### PR TITLE
Avoid ES6 features in untranspiled vendor code.

### DIFF
--- a/vendor/ember-assign-polyfill/index.js
+++ b/vendor/ember-assign-polyfill/index.js
@@ -10,7 +10,12 @@
   }
 
   if (!_Ember.assign) {
-    _Ember.assign = function(...objects) {
+    _Ember.assign = function() {
+      var objects = new Array(arguments.length);
+      for (var i = 0; i < arguments.length; i++) {
+        objects[i] = arguments[i];
+      }
+
       return objects.reduce(Ember.merge);
     };
   }


### PR DESCRIPTION
Code in `vendor/` is not transpiled, using `...objects` will cause phantom (and other non ES6 compliant browsers) to fail.

Fixes https://github.com/shipshapecode/ember-assign-polyfill/issues/7.